### PR TITLE
Seal: Drop chain while feeding data to builder (#482)

### DIFF
--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -291,8 +291,10 @@ where
         }
         let mut builder = B::with_capacity(keys, vals, upds);
 
-        for datum in chain.iter().flat_map(|ts| ts.iter()) {
-            builder.copy(datum);
+        for chunk in chain.drain(..) {
+            for datum in chunk.iter() {
+                builder.copy(datum);
+            }
         }
 
         builder.done(lower.to_owned(), upper.to_owned(), since.to_owned())


### PR DESCRIPTION
Fix a regression where the columnated merge batcher would only deallocate the merged chain after revealing all data to the builder. Instead, it now drains the chain, which deallocates each chunk after revealing its contents to the builder.